### PR TITLE
fix: GitHub Actions 워크플로우 수정 - Release Please 실패 해결

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,8 +10,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🔧 GitHub Actions 실패 문제 해결

### 🚨 문제 상황
Release Please 워크플로우가 지속적으로 실패하고 있었습니다:
- `GitHub Actions is not permitted to create or approve pull requests`
- Deprecated action 사용 경고

### ✅ 해결 방법

#### 1. Action 업데이트
```yaml
# Before (deprecated)
- uses: google-github-actions/release-please-action@v4

# After (current)
- uses: googleapis/release-please-action@v4
```

#### 2. 권한 추가
```yaml
permissions:
  contents: write
  pull-requests: write
  id-token: write  # 추가됨
```

#### 3. Token 명시
```yaml
with:
  release-type: node
  token: ${{ secrets.GITHUB_TOKEN }}  # 명시적 추가
```

### 📈 기대 효과
- ✅ Release Please 워크플로우 정상 작동
- ✅ 자동 버전 관리 및 릴리즈 노트 생성
- ✅ 향후 GitHub Actions 실패 방지

### 🧪 테스트
이 PR이 머지되면 Release Please 액션이 정상적으로 작동하는지 확인할 수 있습니다.

🤖 Generated with Claude Code